### PR TITLE
Fix dropZone property in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ For example, to listen to the `onAllComplete` callback, you need to listen to th
     <div>
         <FineUplaoder :button="button" 
                       :options="options" 
-                      :dropzone="dropzone"
+                      :dropZone="dropZone"
                       @submit="addFileToQueue">
             <div class="drop-area">
                 Drop your files here
@@ -92,7 +92,7 @@ export default {
                 },
                 ...
             },
-            dropzone: {
+            dropZone: {
                 element: '.drop-area',
                 dropActive: 'active'
             },


### PR DESCRIPTION
dropZone property is lowercase in example, but it is camelcase in FineUploader.vue file [https://github.com/Elhebert/vue-fineuploader-dropzone/blob/master/FineUploader.vue#L26]. Therefore, drag and drop doesn't work as excepted.